### PR TITLE
Fixed deadlock when calling dispose when Initialize is not completed

### DIFF
--- a/OBD.NET/OBD.NET.Common/Devices/SerialDevice.cs
+++ b/OBD.NET/OBD.NET.Common/Devices/SerialDevice.cs
@@ -236,6 +236,7 @@ namespace OBD.NET.Common.Devices
         {
             _commandQueue.CompleteAdding();
             _commandCancellationToken?.Cancel();
+            _commandFinishedEvent.Set();
             _commandWorkerTask?.Wait();
             Connection?.Dispose();
         }


### PR DESCRIPTION
This fix is designed to solve the deadlock observed when dispose is called but Initialize method has not yet completed. It happens in async apps if the OBD device is not plugged for example.